### PR TITLE
Bump peer dependency versions to latest

### DIFF
--- a/packages/eslint-config-change-base/package.json
+++ b/packages/eslint-config-change-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-change-base",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Change.org's base ESLint config",
   "main": "index.js",
   "repository": {
@@ -11,20 +11,20 @@
   "license": "MIT",
   "homepage": "https://github.com/change/javascript",
   "dependencies": {
-    "eslint-config-airbnb-base": "^11.1.1"
+    "eslint-config-airbnb-base": "^11.1.3"
   },
   "devDependencies": {
-    "eslint": "^3.17.1",
+    "eslint": "^3.19.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-lodash": "^2.3.5",
-    "eslint-plugin-mocha": "^4.8.0",
+    "eslint-plugin-lodash": "^2.4.0",
+    "eslint-plugin-mocha": "^4.9.0",
     "eslint-plugin-promise": "^3.5.0"
   },
   "peerDependencies": {
-    "eslint": "^3.17.1",
+    "eslint": "^3.19.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-lodash": "^2.3.5",
-    "eslint-plugin-mocha": "^4.8.0",
+    "eslint-plugin-lodash": "^2.4.0",
+    "eslint-plugin-mocha": "^4.9.0",
     "eslint-plugin-promise": "^3.5.0"
   },
   "engines": {

--- a/packages/eslint-config-change-fe/package.json
+++ b/packages/eslint-config-change-fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-change-fe",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Change.org's front-end ESLint config",
   "main": "index.js",
   "repository": {
@@ -12,25 +12,25 @@
   "homepage": "https://github.com/change/javascript",
   "dependencies": {
     "eslint-config-airbnb": "^14.1.0",
-    "eslint-config-change-base": "^1.0.0"
+    "eslint-config-change-base": "^2.0.0"
   },
   "devDependencies": {
-    "eslint": "^3.17.1",
+    "eslint": "^3.19.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
-    "eslint-plugin-lodash": "^2.3.5",
-    "eslint-plugin-mocha": "^4.8.0",
+    "eslint-plugin-lodash": "^2.4.0",
+    "eslint-plugin-mocha": "^4.9.0",
     "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-react": "^6.10.0"
+    "eslint-plugin-react": "^6.10.3"
   },
   "peerDependencies": {
-    "eslint": "^3.17.1",
+    "eslint": "^3.19.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
-    "eslint-plugin-lodash": "^2.3.5",
-    "eslint-plugin-mocha": "^4.8.0",
+    "eslint-plugin-lodash": "^2.4.0",
+    "eslint-plugin-mocha": "^4.9.0",
     "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-react": "^6.10.0"
+    "eslint-plugin-react": "^6.10.3"
   },
   "engines": {
     "node": ">= 6"


### PR DESCRIPTION
@jmerrifield here are the eslint config peerDependency changes I've been trying to test with fe.  I can't get `make npm-check` to pass when these are npm-linked into fe, but I'm currently theorizing that it may be the npm-linking that's part of the issue there... so I'd like to try actually publishing these to npm and just pulling them in normally to fe.  I have verified that fe's lint check passes with these new plugin versions.