### PR TITLE
Bump everything to latest as of Mar 7 2018

### DIFF
--- a/packages/eslint-config-change-base/package.json
+++ b/packages/eslint-config-change-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-change-base",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Change.org's base ESLint config",
   "main": "index.js",
   "repository": {
@@ -11,21 +11,21 @@
   "license": "MIT",
   "homepage": "https://github.com/change/javascript",
   "dependencies": {
-    "eslint-config-airbnb-base": "^11.2.0"
+    "eslint-config-airbnb-base": "^12.1.0"
   },
   "devDependencies": {
-    "eslint": "^3.19.0",
-    "eslint-plugin-import": "^2.7.0",
-    "eslint-plugin-lodash": "^2.4.3",
-    "eslint-plugin-mocha": "^4.11.0",
-    "eslint-plugin-promise": "^3.5.0"
+    "eslint": "^4.18.2",
+    "eslint-plugin-import": "^2.9.0",
+    "eslint-plugin-lodash": "^2.6.1",
+    "eslint-plugin-mocha": "^4.12.1",
+    "eslint-plugin-promise": "^3.6.0"
   },
   "peerDependencies": {
-    "eslint": "^3.19.0",
-    "eslint-plugin-import": "^2.7.0",
-    "eslint-plugin-lodash": "^2.4.3",
-    "eslint-plugin-mocha": "^4.11.0",
-    "eslint-plugin-promise": "^3.5.0"
+    "eslint": "^4.18.2",
+    "eslint-plugin-import": "^2.9.0",
+    "eslint-plugin-lodash": "^2.6.1",
+    "eslint-plugin-mocha": "^4.12.1",
+    "eslint-plugin-promise": "^3.6.0"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/eslint-config-change-fe/package.json
+++ b/packages/eslint-config-change-fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-change-fe",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Change.org's front-end ESLint config",
   "main": "index.js",
   "repository": {
@@ -11,26 +11,26 @@
   "license": "MIT",
   "homepage": "https://github.com/change/javascript",
   "dependencies": {
-    "eslint-config-airbnb": "^15.0.2",
-    "eslint-config-change-base": "^3.0.0"
+    "eslint-config-airbnb": "^16.1.0",
+    "eslint-config-change-base": "^4.0.0"
   },
   "devDependencies": {
-    "eslint": "^3.19.0",
-    "eslint-plugin-import": "^2.7.0",
-    "eslint-plugin-jsx-a11y": "^5.1.1",
-    "eslint-plugin-lodash": "^2.4.3",
-    "eslint-plugin-mocha": "^4.11.0",
-    "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-react": "^7.1.0"
+    "eslint": "^4.18.2",
+    "eslint-plugin-import": "^2.9.0",
+    "eslint-plugin-jsx-a11y": "^6.0.3",
+    "eslint-plugin-lodash": "^2.6.1",
+    "eslint-plugin-mocha": "^4.12.1",
+    "eslint-plugin-promise": "^3.6.0",
+    "eslint-plugin-react": "^7.7.0"
   },
   "peerDependencies": {
-    "eslint": "^3.19.0",
-    "eslint-plugin-import": "^2.7.0",
-    "eslint-plugin-jsx-a11y": "^5.1.1",
-    "eslint-plugin-lodash": "^2.4.3",
-    "eslint-plugin-mocha": "^4.11.0",
-    "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-react": "^7.1.0"
+    "eslint": "^4.18.2",
+    "eslint-plugin-import": "^2.9.0",
+    "eslint-plugin-jsx-a11y": "^6.0.3",
+    "eslint-plugin-lodash": "^2.6.1",
+    "eslint-plugin-mocha": "^4.12.1",
+    "eslint-plugin-promise": "^3.6.0",
+    "eslint-plugin-react": "^7.7.0"
   },
   "engines": {
     "node": ">= 6"


### PR DESCRIPTION
@quaelin not sure if this is consistent with how you've updated these modules previously - I just updated `package.json` by hand to refer to NPM's latest version of everything, and bumped the `eslint-config-change-*` packages by a major version, since it seemed like plenty of breaking changes.

FE PR in the works to bring it up to date with all of these changes.