### PR TITLE
Disable some rules from the 'security' plugin

### DIFF
--- a/packages/eslint-config-change-base/security.js
+++ b/packages/eslint-config-change-base/security.js
@@ -6,4 +6,14 @@ module.exports = {
   extends: [
     'plugin:security/recommended',
   ],
+  
+  rules: {
+    // This is already done by import/no-dynamic-require
+    'security/detect-non-literal-require': 'off',
+    
+    // This rule matches `fs` function names like ('exists', 'truncate')
+    // regardless of whether invoked against the `fs` module and triggers
+    // false positives for innocuous code like `_.truncate(someString)`
+    'security/detect-non-literal-fs-filename': 'off',
+  },
 };


### PR DESCRIPTION
One rule is, from what I can tell, an exact duplicate of an existing rule from the `import` plugin.

The `detect-non-literal-fs-filename` rule generates many false positives. We could probably fix it and open a PR against the project, the issue is described in https://github.com/nodesecurity/eslint-plugin-security/issues/26