### PR TITLE
Allow extend with spread argument

### DIFF
--- a/packages/change-codemod/README.md
+++ b/packages/change-codemod/README.md
@@ -39,7 +39,7 @@ https://astexplorer.net/ is very helpful here.
 
 See https://github.com/facebook/jscodeshift#unit-testing
 
-#### Implementing a make task for your codemod
+#### Implementing an npm script for your codemod
 
 ```
     "lodash-to-object-spread": "TRANSFORM_PATH=path/to/your/transform.js npm run codemod && TRANSFORM_PATH=path/to/another/transform.js npm run codemod"

--- a/packages/change-codemod/package.json
+++ b/packages/change-codemod/package.json
@@ -3,12 +3,16 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/change/javascript"
+  },
   "scripts": {
     "test": "eslint . && jest",
     "codemod": "jscodeshift -t $TRANSFORM_PATH --extensions=js,jsx --ignore-config=$TARGET/.gitignore --printOptions='{ \"trailingCommma\": true }' $TARGET",
     "lodash-to-object-spread": "TRANSFORM_PATH=transforms/lodash-to-object-assign.js npm run codemod && TRANSFORM_PATH=node_modules/js-codemod/transforms/rm-object-assign.js npm run codemod"
   },
-  "author": "",
+  "author": "Change Engineering",
   "license": "ISC",
   "dependencies": {
     "js-codemod": "git+ssh://git@github.com/cpojer/js-codemod.git#0677c0b6029031e4f71bbbfc406a0465e6f7acd2",

--- a/packages/change-codemod/package.json
+++ b/packages/change-codemod/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "change-codemod",
+  "name": "@change-org/change-codemod",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/eslint-plugin-change/README.md
+++ b/packages/eslint-plugin-change/README.md
@@ -1,4 +1,4 @@
-# change-codemod
+# eslint-plugin-change
 
 Custom lint rules for change javascript repos.
 
@@ -16,6 +16,8 @@ npm install
 ```
 _.extend(foo, { bar: 'baz' });
 _.assignIn(foo, { bar: 'baz' });
+_.extend({}, ...foo);
+_.assignIn({}, ...foo);
 ```
 
 #### Invalid

--- a/packages/eslint-plugin-change/package.json
+++ b/packages/eslint-plugin-change/package.json
@@ -22,5 +22,8 @@
     "eslint-plugin-security": "^1.4.0",
     "jest": "^23.6.0",
     "prettier": "^1.15.2"
+  },
+  "dependencies": {
+    "lodash": "^4.17.11"
   }
 }

--- a/packages/eslint-plugin-change/package.json
+++ b/packages/eslint-plugin-change/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "eslint-plugin-change",
-  "version": "1.0.0",
+  "name": "@change-org/eslint-plugin-change",
+  "version": "1.1.0",
   "description": "Eslint rules for change javascript repos",
   "main": "index.js",
   "repository": {

--- a/packages/eslint-plugin-change/package.json
+++ b/packages/eslint-plugin-change/package.json
@@ -3,10 +3,14 @@
   "version": "1.0.0",
   "description": "Eslint rules for change javascript repos",
   "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/change/javascript"
+  },
   "scripts": {
     "test": "eslint . && jest"
   },
-  "author": "",
+  "author": "Change Engineering",
   "license": "ISC",
   "devDependencies": {
     "babel-core": "^6.26.3",

--- a/packages/eslint-plugin-change/rules/__tests__/prefer-object-spread-to-lodash.test.js
+++ b/packages/eslint-plugin-change/rules/__tests__/prefer-object-spread-to-lodash.test.js
@@ -1,7 +1,7 @@
 const { RuleTester } = require('eslint');
 const rule = require('../prefer-object-spread-to-lodash');
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
 
 ruleTester.run('prefer-object-spread-to-lodash', rule, {
   valid: [
@@ -10,6 +10,12 @@ ruleTester.run('prefer-object-spread-to-lodash', rule, {
     },
     {
       code: "_.assignIn(foo, { bar: 'baz' });",
+    },
+    {
+      code: '_.extend({}, ...foo);',
+    },
+    {
+      code: '_.assignIn({}, ...foo);',
     },
   ],
   invalid: [

--- a/packages/eslint-plugin-change/rules/prefer-object-spread-to-lodash.js
+++ b/packages/eslint-plugin-change/rules/prefer-object-spread-to-lodash.js
@@ -1,13 +1,16 @@
+const fp = require('lodash/fp');
+
 const isLodashCall = node => node.callee && node.callee.type === 'MemberExpression' && node.callee.object.name === '_';
 const isExtendOrAssignInCall = node =>
   isLodashCall(node) && (node.callee.property.name === 'extend' || node.callee.property.name === 'assignIn');
 const firstArgumentIsObjectExpression = node => node.arguments && node.arguments[0].type === 'ObjectExpression';
+const hasSpreadArgument = node => fp.some(argument => argument.type === 'SpreadElement')(node.arguments);
 
 module.exports = {
   create(context) {
     return {
       CallExpression(node) {
-        if (isExtendOrAssignInCall(node) && firstArgumentIsObjectExpression(node))
+        if (isExtendOrAssignInCall(node) && firstArgumentIsObjectExpression(node) && !hasSpreadArgument(node))
           context.report(
             node,
             `Use object spread syntax instead of _.${node.callee.property.name} on object literals.`


### PR DESCRIPTION
Fixes an inconsistency between the codemod and the lint rule—the lint rule would prevent use of `_.extend({}, ...foo)` even though there's not an equivalent syntax for object spread.

I'm not sure if we actually use this, but I think we should allow for it.

Also adds some missing package.json fields in both `change-codemod` and `eslint-plugin-change`

@quaelin @jmerrifield 