### PR TITLE
Update eslint and plugins; including security fix for eslint-plugin-lodash

### DIFF
--- a/packages/eslint-config-change-base/package.json
+++ b/packages/eslint-config-change-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-change-base",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "Change.org's base ESLint config",
   "main": "index.js",
   "repository": {

--- a/packages/eslint-config-change-base/package.json
+++ b/packages/eslint-config-change-base/package.json
@@ -11,31 +11,31 @@
   "license": "MIT",
   "homepage": "https://github.com/change/javascript",
   "dependencies": {
-    "eslint-config-airbnb-base": "^13.1.0"
+    "eslint-config-airbnb-base": "^13.2.0"
   },
   "devDependencies": {
     "@change-org/eslint-plugin-change": "^1.1.0",
-    "eslint": "^5.15.2",
-    "eslint-config-prettier": "^4.1.0",
-    "eslint-plugin-import": "^2.16.0",
-    "eslint-plugin-jest": "^22.4.1",
-    "eslint-plugin-lodash": "^5.1.0",
-    "eslint-plugin-mocha": "^5.3.0",
-    "eslint-plugin-prettier": "^3.0.1",
-    "eslint-plugin-promise": "^4.0.1",
+    "eslint": "^5.16.0",
+    "eslint-config-prettier": "^6.0.0",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jest": "^22.15.0",
+    "eslint-plugin-lodash": "^6.0.0",
+    "eslint-plugin-mocha": "^6.0.0",
+    "eslint-plugin-prettier": "^3.1.0",
+    "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-security": "^1.4.0",
-    "prettier": "^1.16.4"
+    "prettier": "^1.18.2"
   },
   "peerDependencies": {
     "@change-org/eslint-plugin-change": "1.x",
-    "eslint": "5.x >= 5.15.2",
+    "eslint": "5.x >=5.15.2",
     "eslint-plugin-import": "2.x >=2.16.0",
-    "eslint-plugin-lodash": "5.x >=5.1.0",
+    "eslint-plugin-lodash": "6.x",
     "eslint-plugin-promise": "4.x >=4.0.1",
     "eslint-plugin-security": "1.x >=1.4.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "scripts": {
     "test": "eslint ."

--- a/packages/eslint-config-change-fe/package.json
+++ b/packages/eslint-config-change-fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-change-fe",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "Change.org's front-end ESLint config",
   "main": "index.js",
   "repository": {
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/change/javascript",
   "dependencies": {
     "eslint-config-airbnb": "^17.1.1",
-    "eslint-config-change-base": "^8.0.0"
+    "eslint-config-change-base": "^9.0.0"
   },
   "devDependencies": {
     "@change-org/eslint-plugin-change": "^1.1.0",

--- a/packages/eslint-config-change-fe/package.json
+++ b/packages/eslint-config-change-fe/package.json
@@ -11,24 +11,24 @@
   "license": "MIT",
   "homepage": "https://github.com/change/javascript",
   "dependencies": {
-    "eslint-config-airbnb": "^17.1.0",
+    "eslint-config-airbnb": "^17.1.1",
     "eslint-config-change-base": "^8.0.0"
   },
   "devDependencies": {
     "@change-org/eslint-plugin-change": "^1.1.0",
-    "eslint": "^5.15.2",
-    "eslint-config-prettier": "^4.1.0",
+    "eslint": "^5.16.0",
+    "eslint-config-prettier": "^6.0.0",
     "eslint-import-resolver-node": "^0.3.2",
-    "eslint-plugin-import": "^2.16.0",
-    "eslint-plugin-jest": "^22.4.1",
-    "eslint-plugin-jsx-a11y": "^6.2.1",
-    "eslint-plugin-lodash": "^5.1.0",
-    "eslint-plugin-mocha": "^5.3.0",
-    "eslint-plugin-prettier": "^3.0.1",
-    "eslint-plugin-promise": "^4.0.1",
-    "eslint-plugin-react": "^7.12.4",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jest": "^22.15.0",
+    "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-lodash": "^6.0.0",
+    "eslint-plugin-mocha": "^6.0.0",
+    "eslint-plugin-prettier": "^3.1.0",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-security": "^1.4.0",
-    "prettier": "^1.16.4"
+    "prettier": "^1.18.2"
   },
   "peerDependencies": {
     "@change-org/eslint-plugin-change": "1.x",
@@ -37,13 +37,13 @@
     "eslint-plugin-import": "2.x >=2.16.0",
     "eslint-plugin-jest": "22.x >=22.4.1",
     "eslint-plugin-jsx-a11y": "6.x >=6.2.1",
-    "eslint-plugin-lodash": "5.x >=5.1.0",
+    "eslint-plugin-lodash": "6.x",
     "eslint-plugin-promise": "4.x >=4.0.1",
     "eslint-plugin-react": "7.x >=7.12.4",
     "eslint-plugin-security": "1.x >=1.4.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "scripts": {
     "test": "eslint ."


### PR DESCRIPTION
There are updates available to eslint and a lot of the plugins we use, including a security update to `eslint-plugin-lodash`.  Also, dropping support for Node 6.