### PR TITLE
Remove @change-org/eslint-plugin-change as a peerDependency

### DIFF
--- a/packages/eslint-config-change-base/package.json
+++ b/packages/eslint-config-change-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-change-base",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Change.org's base ESLint config",
   "main": "index.js",
   "repository": {
@@ -27,7 +27,6 @@
     "prettier": "^1.18.2"
   },
   "peerDependencies": {
-    "@change-org/eslint-plugin-change": "1.x",
     "eslint": "5.x >=5.15.2",
     "eslint-plugin-import": "2.x >=2.16.0",
     "eslint-plugin-lodash": "6.x",

--- a/packages/eslint-config-change-fe/package.json
+++ b/packages/eslint-config-change-fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-change-fe",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Change.org's front-end ESLint config",
   "main": "index.js",
   "repository": {
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/change/javascript",
   "dependencies": {
     "eslint-config-airbnb": "^17.1.1",
-    "eslint-config-change-base": "^9.0.0"
+    "eslint-config-change-base": "^10.0.0"
   },
   "devDependencies": {
     "@change-org/eslint-plugin-change": "^1.1.0",
@@ -31,7 +31,6 @@
     "prettier": "^1.18.2"
   },
   "peerDependencies": {
-    "@change-org/eslint-plugin-change": "1.x",
     "eslint": "5.x >=5.15.2",
     "eslint-import-resolver-node": "0.3.x >=0.3.2",
     "eslint-plugin-import": "2.x >=2.16.0",


### PR DESCRIPTION
Having `@change-org/eslint-plugin-change` as a peerDependency of `eslint-config-change-base` has been annoying, since it is rarely actually used, but needs to be included to silence npm warnings.