### PR TITLE
Allow ESLint v7 in eslint-config-change-base

### DIFF
--- a/packages/eslint-config-change-base/package.json
+++ b/packages/eslint-config-change-base/package.json
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "@change-org/eslint-plugin-change": "1.x",
-    "eslint": "5.x >=5.15.2",
+    "eslint": ">=5.15.2",
     "eslint-plugin-import": "2.x >=2.16.0",
     "eslint-plugin-lodash": ">= 6",
     "eslint-plugin-promise": "4.x >=4.0.1",

--- a/packages/eslint-config-change-base/package.json
+++ b/packages/eslint-config-change-base/package.json
@@ -27,12 +27,12 @@
     "prettier": "^2.2.1"
   },
   "peerDependencies": {
-    "@change-org/eslint-plugin-change": "1.x",
-    "eslint": ">=5.15.2",
-    "eslint-plugin-import": "2.x >=2.16.0",
-    "eslint-plugin-lodash": ">= 6",
-    "eslint-plugin-promise": "4.x >=4.0.1",
-    "eslint-plugin-security": "1.x >=1.4.0"
+    "@change-org/eslint-plugin-change": ">=1",
+    "eslint": ">=5",
+    "eslint-plugin-import": ">=2",
+    "eslint-plugin-lodash": ">=6",
+    "eslint-plugin-promise": ">=4",
+    "eslint-plugin-security": ">=1"
   },
   "engines": {
     "node": ">= 8"

--- a/packages/eslint-config-change-base/package.json
+++ b/packages/eslint-config-change-base/package.json
@@ -15,16 +15,16 @@
   },
   "devDependencies": {
     "@change-org/eslint-plugin-change": "^1.1.0",
-    "eslint": "^5.16.0",
-    "eslint-config-prettier": "^6.11.0",
-    "eslint-plugin-import": "^2.22.0",
-    "eslint-plugin-jest": "^23.18.0",
+    "eslint": "^7.18.0",
+    "eslint-config-prettier": "^7.2.0",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-jest": "^24.1.3",
     "eslint-plugin-lodash": "^7.1.0",
-    "eslint-plugin-mocha": "^7.0.1",
-    "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-mocha": "^8.0.0",
+    "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-security": "^1.4.0",
-    "prettier": "^2.0.5"
+    "prettier": "^2.2.1"
   },
   "peerDependencies": {
     "@change-org/eslint-plugin-change": "1.x",

--- a/packages/eslint-config-change-base/package.json
+++ b/packages/eslint-config-change-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-change-base",
-  "version": "12.0.0",
+  "version": "13.0.0",
   "description": "Change.org's base ESLint config",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Corgi is using ESLint 7.18.0 with eslint-config-change-base v12.0.0, so they would appear to be compatible.