### PR TITLE
Update to non-deprecated CircleCI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     parallelism: 1
     working_directory: ~/change/javascript
     docker:
-    - image: circleci/node:10-stretch
+    - image: cimg/node:14.17
 
     steps:
     - checkout


### PR DESCRIPTION
https://circleci.com/docs/2.0/next-gen-migration-guide/